### PR TITLE
Added members/signup API support

### DIFF
--- a/src/Emma.php
+++ b/src/Emma.php
@@ -138,6 +138,16 @@
 		}
 		
 		/**
+		* Takes the necessary actions to signup a member and enlist them in the provided group ids. You can send the same member multiple times and pass in new group ids to signup.
+		* @param array $member_data	Array of options
+		* @access public
+		* @return the member_id of the member, and their status. The status will be reported as 'a' (active), 'e' (error), or 'o' (optout).
+		*/
+		function membersSignup($member_data = array()) {
+			return $this->post("/members/signup", $member_data);
+		}
+		
+		/**
 		* Delete an array of members. The members will be marked as deleted and cannot be retrieved.
 		* @param array $params		Array of options
 		* @access public

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -60,6 +60,16 @@
 			$this->assertSelectRegExp('member_id', '/member_id/', false, $req);
 		}
 		
+		public function testmembersSignup() {
+			$rand = $this->_generateRandomString();
+			$member = array();
+			$member['email'] = 'dennismonsewicz+' . $rand .'@gmail.com';
+			$member['fields'] = array('first_name' => 'Hola');
+			$member['group_ids'] = array(1223);
+			$req = json_decode($this->em->membersSignup($member));
+			$this->assertSelectRegExp('member_id', '/member_id/', false, $req);
+		}
+		
 		public function testmembersRemove() {
 			$members = array('member_ids' => array(101, 102));
 			$req = json_decode($this->em->membersRemove($members));


### PR DESCRIPTION
I went ahead and added support for the members/signup API call. This API call allows members to be added to Emma as members of specific audience groups and further allows a signup form to be specified for use with signup-based triggers.
