### PR TITLE
Clean the params when using get()

### DIFF
--- a/src/Emma.php
+++ b/src/Emma.php
@@ -957,7 +957,11 @@
 		protected function get($path, $params = array()) {
 			$this->_params = array_merge($params, $this->_params);
 			$url = $this->_constructUrl($path);
-			return $this->_request($url);
+			$req = $this->_request($url);
+			foreach($params as $key => $value) {
+				unset($this->_params[$key]);
+			}
+			return $req;
 		}
 		
 		/**


### PR DESCRIPTION
Partially addresses issue #5 

Reversing the order of the array_marge() on L:962 works for straight pagination, but if you start with a count=true parameter, that gets stuck in there so that none of the subsequent calls to any method involving get() continues to return the count. This solution assumes that you're looking to get something different every time, so clean out all the params you set and leave it like you found it for the next call.