### PR TITLE
Enforce https connection using TLSv1.2

### DIFF
--- a/src/Emma.php
+++ b/src/Emma.php
@@ -1019,7 +1019,8 @@
 			$ch = curl_init($url);
 			curl_setopt($ch, CURLOPT_USERPWD, "{$this->_pub_key}:{$this->_priv_key}");
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+            curl_setopt($ch, CURLOPT_SSLVERSION, 6);
 			
 			if(isset($verb)) {
 				if($verb == "post") {


### PR DESCRIPTION
Emma's API no longer supports TLSv1 or lower. This PR will force use of
TLSv1.2 for connections to the API.